### PR TITLE
Remove 1991 (all NA's) from Cowley data

### DIFF
--- a/R/get_cowley_data.R
+++ b/R/get_cowley_data.R
@@ -12,7 +12,8 @@ get_cowley_lizards <- function()
     data_path <- system.file("extdata", "cowleylizards.txt",
                              package = "MATSS", mustWork = TRUE)
     raw_data <- read.delim(data_path) %>%
-        dplyr::mutate_if(is.numeric,list(~dplyr::na_if(., -99)))
+        dplyr::mutate_if(is.numeric,list(~dplyr::na_if(., -99))) %>%
+        dplyr::filter(!is.na(Cnemnidophorous_sexlineatus))
     
     list(abundance = dplyr::select(raw_data, -c(Year,Site,Total)), 
          covariates = dplyr::select(raw_data, Year),
@@ -40,7 +41,8 @@ get_cowley_snakes <- function()
     data_path <- system.file("extdata", "cowleysnakes.txt",
                              package = "MATSS", mustWork = TRUE)
     raw_data <- read.delim(data_path) %>%
-        dplyr::mutate_if(is.numeric,list(~dplyr::na_if(., -99)))
+        dplyr::mutate_if(is.numeric,list(~dplyr::na_if(., -99))) %>%
+        dplyr::filter(!is.na(Agkistrodon_contortrix))
     
     list(abundance = dplyr::select(raw_data, -c(Year,Site,Total)), 
          covariates = dplyr::select(raw_data, Year),

--- a/tests/testthat/test-02-datasets.R
+++ b/tests/testthat/test-02-datasets.R
@@ -38,13 +38,13 @@ test_that("Karoo data is retrievable and works", {
 test_that("Cowley Lizards data is retrievable and works", {
     expect_error(cowley_lizards_data <- get_cowley_lizards(), NA)
     expect_true(check_data_format(cowley_lizards_data))
-    expect_known_hash(cowley_lizards_data, "32c1612a83")
+    expect_known_hash(cowley_lizards_data, "790a7d013b")
 })
 
 test_that("Cowley Snakes data is retrievable and works", {
     expect_error(cowley_snakes_data <- get_cowley_snakes(), NA)
     expect_true(check_data_format(cowley_snakes_data))
-    expect_known_hash(cowley_snakes_data, "beb0aac9c9")
+    expect_known_hash(cowley_snakes_data, "1605432bba")
 })
 
 test_that("Kruger data is retrievable and works", {


### PR DESCRIPTION
All species are NA in 1991 in the Cowley data. This adds a line to remove that year from both the `abundance` and `covariates` tables.

I was motivated to do this because LDATS/MATSS-LDATS needs an abundance table without NAs. I can definitely see an argument for having the user do this step on their own, but I put it here because
- I'm pretty sure we have been skipping missing censuses, rather than having a NA line (this is how I've done all the stuff I've done with LDATS at Portal) 
- Doing the cleaning in MATSS-LDATS would make the plans/plan generating functions a tiny bit less beautifully organized 😛  Which is fine if putting it in MATSS seems weird. 