### PR TITLE
Update build_plans.R

### DIFF
--- a/R/build_plans.R
+++ b/R/build_plans.R
@@ -129,6 +129,10 @@ build_bbs_datasets_plan <- function(data_path = get_default_data_path(), bbs_sub
     }
 
     routes_and_regions <- read.csv(routes_and_regions_file, colClasses = "character")
+    
+    if(!is.null(bbs_subset)) {
+        routes_and_regions <- routes_and_regions[bbs_subset, ]
+    }
    
     bbs_datasets <- drake::drake_plan(
         bbs_data_rtrg = target(get_bbs_route_region_data(route, region, path = !!data_path),


### PR DESCRIPTION
Add `bbs_subset` to `build_bbs_datasets_plan` so that the subset argument gets used properly.

It's currently set up so the `bbs_subset` only gets used if you run `prepare_bbs_data`, which users generally won't once the data has all been prepared. This adds a subsetting step to `build_bbs_datasets_plan` so we can pull a subset of the *processed* data for a shorter plan.